### PR TITLE
Make the mfb-button clickable to link to an hyperlink.

### DIFF
--- a/src/mfb-directive.js
+++ b/src/mfb-directive.js
@@ -9,7 +9,7 @@
     '<ul class="mfb-component--{{position}} mfb-{{effect}}"' +
     '    data-mfb-toggle="{{togglingMethod}}" data-mfb-state="{{menuState}}">' +
     '  <li class="mfb-component__wrap">' +
-    '    <a ng-click="clicked()" ng-mouseenter="hovered()" ng-mouseleave="hovered()"' +
+    '    <a ng-href="{{ngHref}}" ng-click="clicked()" ng-mouseenter="hovered()" ng-mouseleave="hovered()"' +
     '       ng-attr-data-mfb-label="{{label}}" class="mfb-component__button--main">' +
     '     <i class="mfb-component__main-icon--resting {{resting}}"></i>' +
     '     <i class="mfb-component__main-icon--active {{active}}"></i>' +
@@ -24,7 +24,7 @@
     '<ul class="mfb-component--{{position}} mfb-{{effect}}"' +
     '    data-mfb-toggle="{{togglingMethod}}" data-mfb-state="{{menuState}}">' +
     '  <li class="mfb-component__wrap">' +
-    '    <a ng-click="clicked()" ng-mouseenter="hovered()" ng-mouseleave="hovered()"' +
+    '    <a ng-href="{{ngHref}}" ng-click="clicked()" ng-mouseenter="hovered()" ng-mouseleave="hovered()"' +
     '       style="background: transparent; box-shadow: none;"' +
     '       ng-attr-data-mfb-label="{{label}}" class="mfb-component__button--main">' +
     '     <md-button class="md-fab md-primary" aria-label={{label}}>' +
@@ -73,6 +73,7 @@
         label: '@',
         resting: '@restingIcon',
         active: '@activeIcon',
+	ngHref: '@',
 
         menuState: '=?',
         togglingMethod: '@',

--- a/test/unit.spec.js
+++ b/test/unit.spec.js
@@ -40,14 +40,14 @@ describe('ng-mfb', function() {
       expect(node.find('ul').hasClass('mfb-component__list')).toBeTruthy();
     });
 
-    it('should be possibile to be instantiated as an attribute', function(){
+    it('should be possible to be instantiated as an attribute', function(){
         var tpl = '<div mfb-menu></div>',
             node = compile(tpl);
 
         expect(node.parent().find('ul')).toBeTruthy();
     });
 
-    it('should be possibile to be instantiated as an element', function(){
+    it('should be possible to be instantiated as an element', function(){
         var tpl = '<mfb-menu></mfb-menu>',
             node = compile(tpl);
 
@@ -91,7 +91,7 @@ describe('ng-mfb', function() {
 
   describe('when passing an option to the effect attribute', function(){
 
-    it('should assign the correspondig animation class', function(){
+    it('should assign the corresponding animation class', function(){
 
       var tpl = '<div mfb-menu effect="zoomin"></div>';
 
@@ -141,6 +141,19 @@ describe('ng-mfb', function() {
       var icon2 = main_button.find('i').eq(1);
       expect( icon2.hasClass('mfb-component__main-icon--active') ).toBeTruthy();
       expect( icon2.hasClass('ion-edit') ).toBeTruthy();
+    });
+  });
+  
+  describe('when passing value to ng-href attribute', function(){
+
+    it('should assign the corresponding ng-href attribute to the element A', function(){
+
+      var tpl = '<div mfb-menu ng-href="#/"></div>';
+
+      var node = compile(tpl);
+      $rootScope.$digest();
+
+      expect(node[0].getAttribute('ng-href')).toBe('#/');
     });
   });
 


### PR DESCRIPTION
Here is a version that allow for the mfb-menu to support ng-href and be used for navigation, not just to open the sub-menu.