### PR TITLE
adding mfbButtonClose to be able to close menu on click or losing focus

### DIFF
--- a/.jsbeautifyrc
+++ b/.jsbeautifyrc
@@ -1,0 +1,12 @@
+{
+  "indent_size": 2,
+  "indent_char": " ",
+  "other": " ",
+  "indent_level": 0,
+  "indent_with_tabs": false,
+  "preserve_newlines": true,
+  "max_preserve_newlines": 2,
+  "jslint_happy": false,
+  "indent_handlebars": true,
+  "object": {}
+}

--- a/README.md
+++ b/README.md
@@ -253,6 +253,17 @@ $scope.buttons = [{
 <!-- this will output 3 buttons with different icon, label and so on-->
 <a mfb-button label="{{button.label}}" icon="{{button.icon}}" ng-repeat="button in buttons"></a>
 ```
+
+#### `mfb-button-close` attribute
+
+When using the toggling method click ```<ul mfb-menu toggling-method="click">``` only the main button toggles the menu. If you want your secondary buttons to close the menu as well you can use the ```mfb-button-close``` attribute on your ```mfb-button```.
+
+That way if your ```mfb-button``` opens a modal or something else that loses focus, your menu will close.
+
+```html
+<button mfb-button mfb-button-close>Closes the menu</button>
+```
+
 <a name="custom-tpls"></a>
 ### Customising templates
 Custom templates can be passed as a attributes to the directive. Just pass either the url of your own template or the ID of the script containing your template. Refer to the default templates provided to have a working base to build upon.

--- a/src/mfb-directive.js
+++ b/src/mfb-directive.js
@@ -1,4 +1,4 @@
-+(function(window, angular, undefined){
++(function(window, angular, undefined) {
 
   'use strict';
 
@@ -6,63 +6,76 @@
 
   mfb.run(['$templateCache', function($templateCache) {
     $templateCache.put('ng-mfb-menu-default.tpl.html',
-    '<ul class="mfb-component--{{position}} mfb-{{effect}}"' +
-    '    data-mfb-toggle="{{togglingMethod}}" data-mfb-state="{{menuState}}">' +
-    '  <li class="mfb-component__wrap">' +
-    '    <a ng-click="clicked()" ng-mouseenter="hovered()" ng-mouseleave="hovered()"' +
-    '       ng-attr-data-mfb-label="{{label}}" class="mfb-component__button--main">' +
-    '     <i class="mfb-component__main-icon--resting {{resting}}"></i>' +
-    '     <i class="mfb-component__main-icon--active {{active}}"></i>' +
-    '    </a>' +
-    '    <ul class="mfb-component__list" ng-transclude>' +
-    '    </ul>' +
-    '</li>' +
-    '</ul>'
+      '<ul class="mfb-component--{{position}} mfb-{{effect}}"' +
+      '    data-mfb-toggle="{{togglingMethod}}" data-mfb-state="{{menuState}}">' +
+      '  <li class="mfb-component__wrap">' +
+      '    <a ng-click="clicked()" ng-mouseenter="hovered()" ng-mouseleave="hovered()"' +
+      '       ng-attr-data-mfb-label="{{label}}" class="mfb-component__button--main">' +
+      '     <i class="mfb-component__main-icon--resting {{resting}}"></i>' +
+      '     <i class="mfb-component__main-icon--active {{active}}"></i>' +
+      '    </a>' +
+      '    <ul class="mfb-component__list" ng-transclude>' +
+      '    </ul>' +
+      '</li>' +
+      '</ul>'
     );
 
     $templateCache.put('ng-mfb-menu-md.tpl.html',
-    '<ul class="mfb-component--{{position}} mfb-{{effect}}"' +
-    '    data-mfb-toggle="{{togglingMethod}}" data-mfb-state="{{menuState}}">' +
-    '  <li class="mfb-component__wrap">' +
-    '    <a ng-click="clicked()" ng-mouseenter="hovered()" ng-mouseleave="hovered()"' +
-    '       style="background: transparent; box-shadow: none;"' +
-    '       ng-attr-data-mfb-label="{{label}}" class="mfb-component__button--main">' +
-    '     <md-button class="md-fab md-primary" aria-label={{label}} style="position:relative; margin: 0; padding:0;">' +
-    '       <md-icon style="left: 0; position: relative;" md-svg-icon="{{resting}}"' +
-    '         class="mfb-component__main-icon--resting"></md-icon>' +
-    '       <md-icon style="position:relative;" md-svg-icon="{{active}}"' +
-    '         class="mfb-component__main-icon--active"></md-icon>' +
-    '     </md-button>' +
-    '    </a>' +
-    '    <ul class="mfb-component__list" ng-transclude>' +
-    '    </ul>' +
-    '</li>' +
-    '</ul>'
+      '<ul class="mfb-component--{{position}} mfb-{{effect}}"' +
+      '    data-mfb-toggle="{{togglingMethod}}" data-mfb-state="{{menuState}}">' +
+      '  <li class="mfb-component__wrap">' +
+      '    <a ng-click="clicked()" ng-mouseenter="hovered()" ng-mouseleave="hovered()"' +
+      '       style="background: transparent; box-shadow: none;"' +
+      '       ng-attr-data-mfb-label="{{label}}" class="mfb-component__button--main">' +
+      '     <md-button class="md-fab md-primary" aria-label={{label}} style="position:relative; margin: 0; padding:0;">' +
+      '       <md-icon style="left: 0; position: relative;" md-svg-icon="{{resting}}"' +
+      '         class="mfb-component__main-icon--resting"></md-icon>' +
+      '       <md-icon style="position:relative;" md-svg-icon="{{active}}"' +
+      '         class="mfb-component__main-icon--active"></md-icon>' +
+      '     </md-button>' +
+      '    </a>' +
+      '    <ul class="mfb-component__list" ng-transclude>' +
+      '    </ul>' +
+      '</li>' +
+      '</ul>'
     );
 
     $templateCache.put('ng-mfb-button-default.tpl.html',
-    '<li>' +
-    '  <a data-mfb-label="{{label}}" class="mfb-component__button--child">' +
-    '    <i class="mfb-component__child-icon {{icon}}">' +
-    '    </i>' +
-    '  </a>' +
-    '</li>'
+      '<li>' +
+      '  <a data-mfb-label="{{label}}" class="mfb-component__button--child">' +
+      '    <i class="mfb-component__child-icon {{icon}}">' +
+      '    </i>' +
+      '  </a>' +
+      '</li>'
     );
 
     $templateCache.put('ng-mfb-button-md.tpl.html',
-    '<li>' +
-    '  <a href="" data-mfb-label="{{label}}" class="mfb-component__button--child" ' +
-    '     style="background: transparent; box-shadow: none;">' +
-    '     <md-button style="margin: 0;" class="md-fab md-primary" aria-label={{label}}>' +
-    //'       <md-icon md-svg-src="img/icons/android.svg"></md-icon>' +
-    '       <md-icon md-svg-icon="{{icon}}"></md-icon>' +
-    '     </md-button>' +
-    '  </a>' +
-    '</li>'
+      '<li>' +
+      '  <a href="" data-mfb-label="{{label}}" class="mfb-component__button--child" ' +
+      '     style="background: transparent; box-shadow: none;">' +
+      '     <md-button style="margin: 0;" class="md-fab md-primary" aria-label={{label}}>' +
+      //'       <md-icon md-svg-src="img/icons/android.svg"></md-icon>' +
+      '       <md-icon md-svg-icon="{{icon}}"></md-icon>' +
+      '     </md-button>' +
+      '  </a>' +
+      '</li>'
     );
   }]);
 
-  mfb.directive('mfbMenu', ['$timeout',function($timeout){
+  mfb.directive('mfbButtonClose', function($log) {
+    return {
+      restrict: 'A',
+      require: '^mfbMenu',
+      link: function($scope, $element, $attrs, mfbMenuController) {
+        $element.bind('click', function() {
+          mfbMenuController.close();
+        });
+      },
+    };
+
+  });
+
+  mfb.directive('mfbMenu', ['$timeout', function($timeout) {
     return {
       restrict: 'EA',
       transclude: true,
@@ -80,21 +93,86 @@
       templateUrl: function(elem, attrs) {
         return attrs.templateUrl || 'ng-mfb-menu-default.tpl.html';
       },
-      link: function(scope, elem, attrs) {
-
+      controller: function($scope, $attrs) {
         var openState = 'open',
-            closedState = 'closed';
+          closedState = 'closed';
+
+        // Attached toggle, open and close to the controller to give other directive access them
+        // directives such as mfbButtonClose
+        this.toggle = toggle;
+        this.close = close;
+        this.open = open;
+
+        $scope.clicked = clicked;
+        $scope.hovered = hovered;
+
+        /**
+         * Set the state to user-defined value. Fallback to closed if no
+         * value is passed from the outside.
+         */
+        //$scope.menuState = $attrs.menuState || closedState;
+        if (!$scope.menuState) {
+          $scope.menuState = closedState;
+        }
+
+        /**
+         * If on touch device AND 'hover' method is selected:
+         * wait for the digest to perform and then change hover to click.
+         */
+        if (_isTouchDevice() && _isHoverActive()) {
+          $timeout(useClick);
+        }
+
+        $attrs.$observe('menuState', function() {
+          $scope.currentState = $scope.menuState;
+        });
+
+        function clicked() {
+          // If there is a main action, let's fire it
+          if ($scope.mainAction) {
+            $scope.mainAction();
+          }
+
+          if (!_isHoverActive()) {
+            toggle();
+          }
+        };
+
+        function hovered() {
+          if (_isHoverActive()) {
+            //toggle();
+          }
+        };
+
+        /**
+         * Invert the current state of the menu.
+         */
+        function toggle() {
+          if ($scope.menuState === openState) {
+            close();
+          } else {
+            open();
+          }
+        }
+
+        function open() {
+          $scope.menuState = openState;
+        }
+
+        function close() {
+          $scope.menuState = closedState;
+        }
 
         /**
          * Check if we're on a touch-enabled device.
          * Requires Modernizr to run, otherwise simply returns false
          */
-        function _isTouchDevice(){
+        function _isTouchDevice() {
           return window.Modernizr && Modernizr.touch;
         }
 
-        function _isHoverActive(){
-          return scope.togglingMethod === 'hover';
+        function _isHoverActive() {
+          return $scope.togglingMethod === 'hover';
         }
 
         /**
@@ -102,61 +180,16 @@
          * This is used when 'hover' is selected by the user
          * but a touch device is enabled.
          */
-        function useClick(){
-          scope.$apply(function(){
-            scope.togglingMethod = 'click';
+        function useClick() {
+          $scope.$apply(function() {
+            $scope.togglingMethod = 'click';
           });
         }
-        /**
-         * Invert the current state of the menu.
-         */
-        function flipState() {
-          scope.menuState = scope.menuState === openState ? closedState : openState;
-        }
-
-        /**
-         * Set the state to user-defined value. Fallback to closed if no
-         * value is passed from the outside.
-         */
-        //scope.menuState = attrs.menuState || closedState;
-        if(!scope.menuState){
-          scope.menuState = closedState;
-        }
-
-        scope.clicked = function() {
-          // If there is a main action, let's fire it
-          if (scope.mainAction) {
-            scope.mainAction();
-          }
-
-          if(!_isHoverActive()){
-            flipState();
-          }
-        };
-        scope.hovered = function() {
-          if(_isHoverActive()){
-            //flipState();
-          }
-        };
-
-        /**
-         * If on touch device AND 'hover' method is selected:
-         * wait for the digest to perform and then change hover to click.
-         */
-        if ( _isTouchDevice() && _isHoverActive() ){
-          $timeout(useClick);
-        }
-
-        attrs.$observe('menuState', function(){
-          scope.currentState = scope.menuState;
-        });
-
       }
     };
   }]);
 
-
-  mfb.directive('mfbButton', [function(){
+  mfb.directive('mfbButton', [function() {
     return {
       require: '^mfbMenu',
       restrict: 'EA',


### PR DESCRIPTION
adding a directive that close the menu on click:

```
<button mfb-button mfb-button-close></button>
```

If the toggling method is CLICK then as soon as you lose the menu focus (opening a modal or moving mouse out) the menu will close. If the toggling method is HOVER then nothing change.

To be able to access close, open and toggle methods from another directive I change ```mfbMenu``` link to controller.

therefore I can access ```mfbMenu``` controller that way:

```
return {
      restrict: 'A',
      require: '^mfbMenu',
      link: function($scope, $element, $attrs, mfbMenuController) {
        $element.bind('click', function() {
          mfbMenuController.close();
        });
      },
    };
```

I reorganized methods a little bit to follow [angular-styleguide](https://github.com/johnpapa/angular-styleguide) and added a ```.jsbeautifyrc``` file for Atom users.

Tests are ok:

```
PhantomJS 1.9.8 (Linux): Executed 22 of 22 SUCCESS (0.052 secs / 0.21 secs)
```

If you have any question feel free to ask,
Julien